### PR TITLE
error.name を使う処理はVercel上で動作しないので instanceof で判定するように変更

### DIFF
--- a/src/components/ErrorFallback/ErrorMessage.tsx
+++ b/src/components/ErrorFallback/ErrorMessage.tsx
@@ -1,8 +1,9 @@
 import type { FC } from 'react';
 import { Alert } from '@mantine/core';
+import { GitHubAccountNotFoundError } from '@/features';
 
 const createDisplayErrorMessage = (error: Error) => {
-  if (error.name === 'GitHubAccountNotFoundError') {
+  if (error instanceof GitHubAccountNotFoundError) {
     return 'GitHubアカウントは見つかりませんでした。';
   }
 


### PR DESCRIPTION
# issueURL

なし

# この PR で対応する範囲 / この PR で対応しない範囲

- Vercel上でErrorFallbackのMessageの出し分けが正常に動作するようになっている事

# Storybook の URL、 スクリーンショット

## 正常にエラーハンドリングが出来ている事を確認

![ErrorHandling](https://user-images.githubusercontent.com/11032365/219696819-168fae83-50ed-4e3f-b5f2-afc184b4dbec.png)

# 変更点概要

表題の通り。`error.name` を使う処理はVercel上で動作しないので `instanceof` で判定するように変更

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし