### PR TITLE
Storybook上でMSW（MockServiceWorker）を利用出来る設定を追加

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ next-env.d.ts
 *.config.js
 __mocks__
 storybook-static/
+public/mockServiceWorker.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ next-env.d.ts
 *.config.js
 __mocks__
 storybook-static/
+public/mockServiceWorker.js

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -11,4 +11,5 @@ module.exports = {
   core: {
     builder: '@storybook/builder-webpack5',
   },
+  staticDirs: ['../public'],
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,9 @@
+import { initialize, mswDecorator } from 'msw-storybook-addon';
+
+initialize();
+
+export const decorators = [mswDecorator];
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "jest": "^29.4.2",
         "jest-environment-jsdom": "^29.4.2",
         "msw": "^1.0.1",
+        "msw-storybook-addon": "^1.7.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.8.3",
         "storybook-addon-next": "^1.7.1",
@@ -23181,6 +23182,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/msw-storybook-addon": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-1.7.0.tgz",
+      "integrity": "sha512-G/cYj7Z8NuyFbMsdVJRr17flWed8J7CmKTSPNXmuK65W6uILpqNDpXJC7KVRhOg7lUFR5Hmqwcq6z8Mow/wu5A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "^6.0.0",
+        "is-node-process": "^1.0.1"
+      },
+      "peerDependencies": {
+        "msw": ">=0.35.0 <1.0.0"
       }
     },
     "node_modules/msw/node_modules/ansi-styles": {
@@ -48031,6 +48045,16 @@
           "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
           "dev": true
         }
+      }
+    },
+    "msw-storybook-addon": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-1.7.0.tgz",
+      "integrity": "sha512-G/cYj7Z8NuyFbMsdVJRr17flWed8J7CmKTSPNXmuK65W6uILpqNDpXJC7KVRhOg7lUFR5Hmqwcq6z8Mow/wu5A==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "^6.0.0",
+        "is-node-process": "^1.0.1"
       }
     },
     "multipipe": {

--- a/package.json
+++ b/package.json
@@ -69,9 +69,13 @@
     "jest": "^29.4.2",
     "jest-environment-jsdom": "^29.4.2",
     "msw": "^1.0.1",
+    "msw-storybook-addon": "^1.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.3",
     "storybook-addon-next": "^1.7.1",
     "whatwg-fetch": "^3.6.2"
+  },
+  "msw": {
+    "workerDirectory": "public"
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,303 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker (1.0.1).
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const INTEGRITY_CHECKSUM = '3d6b9f06410d179a7f7404d4bf4c3c70'
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: INTEGRITY_CHECKSUM,
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+  const accept = request.headers.get('accept') || ''
+
+  // Bypass server-sent events.
+  if (accept.includes('text/event-stream')) {
+    return
+  }
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  // Generate unique request ID.
+  const requestId = Math.random().toString(16).slice(2)
+
+  event.respondWith(
+    handleRequest(event, requestId).catch((error) => {
+      if (error.name === 'NetworkError') {
+        console.warn(
+          '[MSW] Successfully emulated a network error for the "%s %s" request.',
+          request.method,
+          request.url,
+        )
+        return
+      }
+
+      // At this point, any exception indicates an issue with the original request/response.
+      console.error(
+        `\
+[MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
+        request.method,
+        request.url,
+        `${error.name}: ${error.message}`,
+      )
+    }),
+  )
+})
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const clonedResponse = response.clone()
+      sendToClient(client, {
+        type: 'RESPONSE',
+        payload: {
+          requestId,
+          type: clonedResponse.type,
+          ok: clonedResponse.ok,
+          status: clonedResponse.status,
+          statusText: clonedResponse.statusText,
+          body:
+            clonedResponse.body === null ? null : await clonedResponse.text(),
+          headers: Object.fromEntries(clonedResponse.headers.entries()),
+          redirected: clonedResponse.redirected,
+        },
+      })
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+  const clonedRequest = request.clone()
+
+  function passthrough() {
+    // Clone the request because it might've been already used
+    // (i.e. its body has been read and sent to the client).
+    const headers = Object.fromEntries(clonedRequest.headers.entries())
+
+    // Remove MSW-specific request headers so the bypassed requests
+    // comply with the server's CORS preflight check.
+    // Operate with the headers as an object because request "Headers"
+    // are immutable.
+    delete headers['x-msw-bypass']
+
+    return fetch(clonedRequest, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Bypass requests with the explicit bypass header.
+  // Such requests can be issued by "ctx.fetch()".
+  if (request.headers.get('x-msw-bypass') === 'true') {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const clientMessage = await sendToClient(client, {
+    type: 'REQUEST',
+    payload: {
+      id: requestId,
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers.entries()),
+      cache: request.cache,
+      mode: request.mode,
+      credentials: request.credentials,
+      destination: request.destination,
+      integrity: request.integrity,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+      body: await request.text(),
+      bodyUsed: request.bodyUsed,
+      keepalive: request.keepalive,
+    },
+  })
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'MOCK_NOT_FOUND': {
+      return passthrough()
+    }
+
+    case 'NETWORK_ERROR': {
+      const { name, message } = clientMessage.data
+      const networkError = new Error(message)
+      networkError.name = name
+
+      // Rejecting a "respondWith" promise emulates a network error.
+      throw networkError
+    }
+  }
+
+  return passthrough()
+}
+
+function sendToClient(client, message) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [channel.port2])
+  })
+}
+
+function sleep(timeMs) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeMs)
+  })
+}
+
+async function respondWithMock(response) {
+  await sleep(response.delay)
+  return new Response(response.body, response)
+}

--- a/src/templates/GitHubAccountSearchTemplate/GitHubAccountSearchTemplate.stories.ts
+++ b/src/templates/GitHubAccountSearchTemplate/GitHubAccountSearchTemplate.stories.ts
@@ -1,0 +1,22 @@
+import type { ComponentStoryObj } from '@storybook/react';
+import { rest } from 'msw';
+import { mockFetchGitHubAccount } from '@/mocks';
+import { GitHubAccountSearchTemplate } from '@/templates';
+
+const story = {
+  component: GitHubAccountSearchTemplate,
+};
+
+export default story;
+
+type Story = ComponentStoryObj<typeof GitHubAccountSearchTemplate>;
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        rest.get('https://api.github.com/users/*', mockFetchGitHubAccount),
+      ],
+    },
+  },
+};

--- a/src/templates/GitHubAccountSearchTemplate/GitHubAccountSearchTemplate.stories.ts
+++ b/src/templates/GitHubAccountSearchTemplate/GitHubAccountSearchTemplate.stories.ts
@@ -1,6 +1,10 @@
 import type { ComponentStoryObj } from '@storybook/react';
 import { rest } from 'msw';
-import { mockFetchGitHubAccount } from '@/mocks';
+import {
+  mockFetchGitHubAccount,
+  mockFetchGitHubAccountUnexpectedResponseBody,
+  mockNotFoundError,
+} from '@/mocks';
 import { GitHubAccountSearchTemplate } from '@/templates';
 
 const story = {
@@ -16,6 +20,27 @@ export const Default: Story = {
     msw: {
       handlers: [
         rest.get('https://api.github.com/users/*', mockFetchGitHubAccount),
+      ],
+    },
+  },
+};
+
+export const ShowGitHubAccountNotFoundError: Story = {
+  parameters: {
+    msw: {
+      handlers: [rest.get('https://api.github.com/users/*', mockNotFoundError)],
+    },
+  },
+};
+
+export const ShowUnexpectedResponseBodyError: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        rest.get(
+          'https://api.github.com/users/*',
+          mockFetchGitHubAccountUnexpectedResponseBody
+        ),
       ],
     },
   },


### PR DESCRIPTION
# issueURL

https://github.com/keitakn/next-example/issues/13

# この PR で対応する範囲 / この PR で対応しない範囲

- Storybook上でMSW（MockServiceWorker）が利用出来るようになっている事

# Storybook の URL、 スクリーンショット

![storybook](https://user-images.githubusercontent.com/11032365/220011744-e2998184-2c49-4dc3-97c1-60553b011c34.png)

# 変更点概要

Storybook上でMSW（MockServiceWorker）を利用可能にする `msw-storybook-addon` を導入しました。

テスト時に利用しているMockを使ってGitHubAPIへの通信が発生するComponentのStoryを追加しました。

（参考）https://zenn.dev/rabbit/articles/dd9b04940b93fe

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし