### PR TITLE
CI用のworkflowを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Test And Linter
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
 
 jobs:
   build:
@@ -13,12 +13,12 @@ jobs:
       matrix:
         node-version: [18.x]
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run lint
-    - run: npm test
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: ci
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run lint
+    - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # next-example
 
+[![ci](https://github.com/keitakn/next-example/actions/workflows/ci.yml/badge.svg)](https://github.com/keitakn/next-example/actions/workflows/ci.yml)
+
 Next.js の検証用サンプルプロジェクト、長期メンテナンスは行わない予定。このプロジェクトでは app ディレクトリは使わない。
 
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).


### PR DESCRIPTION
# issueURL

なし

# この PR で対応する範囲 / この PR で対応しない範囲

- `main` ブランチにPRを出した時とマージされた時にCIが実行されるようになっている事

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

CI用のworkflowを追加。

CIでやっている具体的な内容は以下の通りです。

- Linterの実行を行い、ESLintのエラーやPrettierのエラーが残っている場合はworkflowを失敗させる
- Jestによるテストを実行して失敗しているテストが1件でもあった場合はworkflowを失敗させる

CI用のworkflowが通っていない場合、PRのマージを禁止する設定も追加済です。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし