### PR TITLE
appTokenのJWTのpayloadの中身は必要最低限の物に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ GITHUB_OIDC_CLIENT_SECRET=GitHubのOAuth Appのクライントシークレット
 NEXTAUTH_URL=NextAuth.js に必要な設定、アプリケーションのURLを設定する
 NEXTAUTH_SECRET=NextAuth.js に必要な設定。JWTの検証の際に利用する秘密鍵になるので十分に強固な値を設定する
 NEXT_PUBLIC_APP_URL=NEXTAUTH_URLと同じ値を設定
+APP_TOKEN_SECRET_KEY=appToken（JWT形式）の検証の際に利用する秘密鍵になるので十分に強固な値を設定する
 ```

--- a/src/features/auth/__tests__/oidc/isOidcProvider.spec.ts
+++ b/src/features/auth/__tests__/oidc/isOidcProvider.spec.ts
@@ -1,0 +1,14 @@
+import { isOidcProvider } from '@/features';
+
+describe('src/features/auth/oidc.ts isOidcProvider Test Cases', () => {
+  it.each([
+    [true, 'google'],
+    [false, 'amazon'],
+    [false, 1],
+    [false, {}],
+    [false, null],
+    [false, undefined],
+  ])('returns %p when the input is %p', (expected, input) => {
+    expect(isOidcProvider(input)).toBe(expected);
+  });
+});

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -6,7 +6,7 @@ import NextAuth, {
 } from 'next-auth';
 import type { JWT } from 'next-auth/jwt/types';
 import GithubProvider from 'next-auth/providers/github';
-import { isOidcProvider } from '@/features';
+import { appUrls, isOidcProvider } from '@/features';
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -22,6 +22,10 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   callbacks: {
+    // eslint-disable-next-line @typescript-eslint/require-await
+    redirect: async ({ baseUrl }) => {
+      return `${baseUrl}${appUrls.gitHubAccountSearch.path}`;
+    },
     session: async ({
       session,
       token,

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -31,7 +31,17 @@ export const authOptions: NextAuthOptions = {
       token: JWT;
       // eslint-disable-next-line @typescript-eslint/require-await
     }) => {
-      session.appToken = jwt.sign(token, String(process.env.NEXTAUTH_SECRET));
+      if (token.sub != null && token.provider != null) {
+        session.appToken = jwt.sign(
+          {
+            sub: token.sub,
+            provider: token.provider,
+            exp: token.exp,
+            jti: token.jti,
+          },
+          String(process.env.APP_TOKEN_SECRET_KEY)
+        );
+      }
 
       return session;
     },

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -39,8 +39,11 @@ export const authOptions: NextAuthOptions = {
     jwt: async ({ token, account }) => {
       if (account) {
         if (isOidcProvider(account.provider)) {
-          token.accessToken = account.access_token;
           token.provider = account.provider;
+        }
+
+        if (account.access_token != null) {
+          token.accessToken = account.access_token;
         }
       }
 

--- a/src/templates/LoginTemplate/LoginTemplate.tsx
+++ b/src/templates/LoginTemplate/LoginTemplate.tsx
@@ -2,16 +2,12 @@ import type { FC, MouseEvent } from 'react';
 import { Group } from '@mantine/core';
 import { signIn } from 'next-auth/react';
 import { GitHubLoginButton } from '@/components';
-import { appUrls } from '@/features';
-import { appUrl } from '@/features/url/url';
 
 export const LoginTemplate: FC = () => {
   const handleSignIn = async (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
 
-    await signIn('github', {
-      callbackUrl: `${appUrl()}${appUrls.gitHubAccountSearch.path}`,
-    });
+    await signIn('github');
   };
 
   return (

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,5 +1,6 @@
 import type { DefaultSession } from 'next-auth';
 import type { DefaultJWT } from 'next-auth/jwt';
+import type { OidcProvider } from '@/features';
 
 declare module 'next-auth' {
   interface Session extends DefaultSession {
@@ -9,7 +10,10 @@ declare module 'next-auth' {
 
 declare module 'next-auth/jwt' {
   interface JWT extends DefaultJWT {
+    iat: number;
+    exp: number;
+    jti: string;
     accessToken?: string;
-    provider?: 'github' | 'google';
+    provider?: OidcProvider;
   }
 }


### PR DESCRIPTION
# issueURL

https://github.com/keitakn/next-example/issues/29

# この PR で対応する範囲 / この PR で対応しない範囲

- https://github.com/keitakn/next-example/issues/29 のDoneの定義を満たしている事

# Storybook の URL、 スクリーンショット


# 変更点概要

appTokenのセキュリティ対策の為、以下を実施しました。

取得方法は以前と変わらずで下記のように取得出来ます。

```
import { getSession } from 'next-auth/react';

const session = await getSession(context);

// JWT形式の文字列が取得できる
console.log(session?.appToken);
```

## payloadの中身をシンプルな物に変更

```
{
  "sub": "11032365",
  "provider": "github",
  "exp": 1683968449,
  "jti": "94890771-44ec-4674-8021-79d17ff0fbf5",
  "iat": 1681376452
}
```

## 署名に使う秘密鍵を独自の物に変更

`APP_TOKEN_SECRET_KEY` として環境変数に登録します。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

インラインコメントに記載。